### PR TITLE
gitignoreにdocker-compose.ymlを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+docker-compose.yml


### PR DESCRIPTION
.gitignoreにdocker-compose.ymlを追加いたしました。

【理由】
私の環境がm1macのため、mariadbのDockerイメージを使っているのですが、はるきさんとみなみさんはmysqlのDockerイメージでビルドしているため、それぞれがpullするたびに.ymlが書き換えられてしまい、毎回.ymlを自身の環境のものに書き換えないといけないのが手間なため

以上、よろしくお願いいたいます。