### PR TITLE
記事詳細画面作成(諸石)

### DIFF
--- a/src/app/Http/Controllers/ArticlesController.php
+++ b/src/app/Http/Controllers/ArticlesController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Category;
+use App\Article;
 
 class ArticlesController extends Controller
 {
@@ -10,5 +12,10 @@ class ArticlesController extends Controller
     public function create()
     {
         return view('articles.create');
+    }
+
+    public function show(Article $article)
+    {
+        return view('articles.show', compact('article'));
     }
 }

--- a/src/public/css/article/show.css
+++ b/src/public/css/article/show.css
@@ -21,3 +21,17 @@
 .article-show .show-btn a:nth-child(n + 2) {
     margin-left: 15px;
 }
+
+@media only screen and (max-width: 960px) {
+    .article-show .card-body {
+        padding: 0 60px;
+    }
+    .article-show dt {
+        text-align: left;
+        width: 100%;
+    }
+    .article-show dd {
+        width: 100%;
+        padding: 10px 0;
+    }
+}

--- a/src/public/css/article/show.css
+++ b/src/public/css/article/show.css
@@ -1,0 +1,23 @@
+.article-show {
+    width: 700px;
+    max-width: 100%;
+    margin: 0 auto;
+}
+
+.article-show dl {
+    margin-top: 50px;
+}
+.article-show dt {
+    text-align: right;
+    width: 200px;
+}
+.article-show dd {
+    width: 400px;
+    padding: 0 60px;
+}
+.article-show .show-btn a {
+    padding: 15px 20px;
+}
+.article-show .show-btn a:nth-child(n + 2) {
+    margin-left: 15px;
+}

--- a/src/resources/views/articles/show.blade.php
+++ b/src/resources/views/articles/show.blade.php
@@ -35,13 +35,13 @@
             </dl>
             <dl class="row justify-content-center">
                 <dt>URL</dt>
-                <dd><a href="{{ $article->url }}" target="_blank">{{ $article->url }}</a></dd>
+                <dd><a href="{{ $article->url }}" target="_blank" rel="noopener">{{ $article->url }}</a></dd>
             </dl>
             <div class="row my-5 show-btn justify-content-center">
                 <a href="/" class="d-inline-block btn btn-secondary">戻る</a>
                 @auth
                     @if(Auth::id() === $article->user->id)
-                        <a href="#" class="d-inline-block btn btn-success"><i class="far fa-edit mr-1"></i></i>編集</a>
+                        <a href="#" class="d-inline-block btn btn-success"><i class="far fa-edit mr-1"></i>編集</a>
                         <a href="#" class="d-inline-block btn btn-danger"><i class="far fa-trash-alt mr-1"></i>削除</a>
                     @endif
                 @endauth

--- a/src/resources/views/articles/show.blade.php
+++ b/src/resources/views/articles/show.blade.php
@@ -1,0 +1,52 @@
+@extends('layouts.app')
+
+@include('common.header')
+
+@section('css')
+<link href="{{ asset('css/article/show.css') }}" rel="stylesheet">
+@endsection
+
+@section('content')
+<div class="containerr-fluid">
+    <div class="mt-5 card article-show">
+        <div class="card-header text-center font-weight-bold h3">
+            <i class="fas fa-file-code mr-2"></i>記事詳細
+        </div>
+        <div class="card-body">
+            <dl class="row justify-content-center">
+                <dt>名前</dt>
+                <dd>{{ $article->user->name }}</dd>
+            </dl>
+            <dl class="row justify-content-center">
+                <dt>期生</dt>
+                <dd>{{ $article->user->term }}期生</dd>
+            </dl>
+            <dl class="row justify-content-center">
+                <dt>タイトル</dt>
+                <dd>{{ $article->title }}</dd>
+            </dl>
+            <dl class="row justify-content-center">
+                <dt>カテゴリー</dt>
+                <dd>{{ $article->category->name }}</dd>
+            </dl>
+            <dl class="row justify-content-center">
+                <dt>記事概要</dt>
+                <dd>{{ $article->summary }}</dd>
+            </dl>
+            <dl class="row justify-content-center">
+                <dt>URL</dt>
+                <dd><a href="{{ $article->url }}" target="_blank">{{ $article->url }}</a></dd>
+            </dl>
+            <div class="row my-5 show-btn justify-content-center">
+                <a href="/" class="d-inline-block btn btn-secondary">戻る</a>
+                @auth
+                    @if(Auth::id() === $article->user->id)
+                        <a href="#" class="d-inline-block btn btn-success"><i class="far fa-edit mr-1"></i></i>編集</a>
+                        <a href="#" class="d-inline-block btn btn-danger"><i class="far fa-trash-alt mr-1"></i>削除</a>
+                    @endif
+                @endauth
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -22,6 +22,8 @@ Route::get('/home', 'HomeController@index')->name('home');
 Route::get('/articles/create', function () {
     return view('articles/create');
 });
+Route::resource('articles', 'ArticlesController', ['only' => ['show']]);
+
 
 
 Route::get('user', 'UsersController@show');


### PR DESCRIPTION
詳細画面を作成しました。
レビューお願いします。

## 【追加】
- `web.php`にshowアクションへのルーティングを定義
- `ArticleController.php`にshowアクションを追加
- `views/articles`に`show.blade.php`を作成
- cssにarticleフォルダを作り、`show.css`を追加

## 【変更】
なし

## 【削除】
なし

## 【特記事項】
なし

## 【仕様】
- ログイン中のユーザーが投稿した記事（＝自分の記事）の場合のみ、「編集」、「削除」ボタンが表示されるようにする→ok
- なお、ボタン設置のみで遷移先のURLの記載は不要です（記事編集画面の担当者が行う）→ok
