### PR TITLE
記事削除機能追加(諸石)

### DIFF
--- a/src/app/Article.php
+++ b/src/app/Article.php
@@ -3,11 +3,14 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Article extends Model
 {
-    protected $fillable = ['user_id', 'title', 'category_id', 'summary','url'];
+    use SoftDeletes;
     
+    protected $fillable = ['user_id', 'title', 'category_id', 'summary','url'];
+
     public function user()
     {
         return $this->belongsTo(User::class);

--- a/src/app/Http/Controllers/ArticlesController.php
+++ b/src/app/Http/Controllers/ArticlesController.php
@@ -41,6 +41,14 @@ class ArticlesController extends Controller
     {
         $article->fill($request->all())->save();
         return redirect('/');
+    }
+
+    public function destroy($id)
+    {
+        $article = Article::find($id);
+        $this->authorize('delete', $article);
+        $article->delete();
+        return redirect('/')->with('flash_message', '記事を削除しました');
 
     }
 }

--- a/src/app/Policies/ArticlePolicy.php
+++ b/src/app/Policies/ArticlePolicy.php
@@ -65,7 +65,7 @@ class ArticlePolicy
      */
     public function delete(User $user, Article $article)
     {
-        //
+        return $user->id === $article->user_id;
     }
 
     /**

--- a/src/public/js/common.js
+++ b/src/public/js/common.js
@@ -1,5 +1,5 @@
 function Check(){
-    let checked = confirm("削除してもよろしいでしょうか？");
+    let checked = confirm("記事を削除してもよろしいですか？");
     if (checked) {
         return true;
     } else {

--- a/src/public/js/common.js
+++ b/src/public/js/common.js
@@ -1,0 +1,8 @@
+function Check(){
+    let checked = confirm("削除してもよろしいでしょうか？");
+    if (checked) {
+        return true;
+    } else {
+        return false;
+    }
+}

--- a/src/resources/views/articles/index.blade.php
+++ b/src/resources/views/articles/index.blade.php
@@ -13,13 +13,15 @@
                         <p class="d-inline font-weight-bold">{{ $article->user->name }}</p>
                         <!-- ログインしているユーザーのみ編集と削除ボタンを表示 -->
                         @if($user_id == $article->user->id)
-                            <span class="float-right">
+                            <span class="float-right d-flex">
                                 <a href="{{ route('articles.edit', ['article' => $article]) }}" class="btn btn-secondary rounded-pill">
                                     <i class="far fa-edit mr-1"></i>編集
                                 </a>
-                                <a href="#" class="btn btn-danger rounded-pill">
-                                    <i class="far fa-trash-alt mr-1"></i>削除
-                                </a>
+                                <form name="deleteform" method="POST" action="{{ route('articles.destroy', $article->id) }}">
+                                    @method('delete')
+                                    @csrf
+                                    <button type="submit" class="btn btn-danger rounded-pill" onClick="return Check()"><i class="far fa-trash-alt mr-1"></i>削除</button>
+                                </form>
                             </span>
                         @endif
                     </div>

--- a/src/resources/views/articles/show.blade.php
+++ b/src/resources/views/articles/show.blade.php
@@ -41,8 +41,12 @@
                 <a href="/" class="d-inline-block btn btn-secondary">戻る</a>
                 @auth
                     @if(Auth::id() === $article->user->id)
-                        <a href="{{ route('articles.edit', ['article' => $article]) }}" class="d-inline-block btn btn-success"><i class="far fa-edit mr-1"></i>編集</a>
-                        <a href="#" class="d-inline-block btn btn-danger"><i class="far fa-trash-alt mr-1"></i>削除</a>
+                        <a href="#" class="d-inline-block btn btn-success"><i class="far fa-edit mr-1"></i>編集</a>
+                        <form name="deleteform" method="POST" action="{{ route('articles.destroy', $article->id) }}">
+                            @method('delete')
+                            @csrf
+                            <button type="submit" class="py-3 ml-2 btn btn-danger" onClick="return Check()"><i class="far fa-trash-alt mr-1"></i>削除</button>
+                        </form>
                     @endif
                 @endauth
             </div>

--- a/src/resources/views/layouts/app.blade.php
+++ b/src/resources/views/layouts/app.blade.php
@@ -11,6 +11,7 @@
 
     <!-- Scripts -->
     <script src="{{ asset('js/app.js') }}" defer></script>
+    <script src="{{ asset('js/common.js') }}" defer></script>
 
     <!-- fontawesomeインストール -->
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.1/css/all.css">
@@ -26,7 +27,7 @@
 <body>
 
     @yield('header')
-    
+
     <main class="py-4">
         @yield('content')
     </main>

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -24,5 +24,5 @@ Route::resource('articles', 'ArticlesController', ['only' => ['show']]);
 Route::get('user', 'UsersController@show');
 
 Route::group(['middleware' => 'auth'], function () {
-    Route::resource('articles', 'ArticlesController', ['only' => ['edit', 'update']]);
+    Route::resource('articles', 'ArticlesController', ['only' => ['edit', 'update', 'destroy']]);
 });


### PR DESCRIPTION
記事削除機能を作成しました。
レビューお願いします。

## 【追加】
- `web.php`にdestroyアクションへのルーティングを定義
- `ArticleController.php`にdestroyアクションを追加
- `Article.php`にSoftDeletesを追加
- 認可機能追加
- 一覧画面と編集画面に削除のリンク追加
- common.jsを作成し、確認のアラートを表示

## 【変更】
なし

## 【削除】
なし

## 【特記事項】
なし

## 【仕様】
- 削除処理は記事一覧画面、記事詳細画面、マイページ画面から行えるようにする。（ボタンは各画面の担当者が設置）→ok
(マイページ出来次第リンク繋ぎます)
- 削除方法は論理削除とする（物理削除にしない）→ok
- 論理削除完了後は記事一覧画面にリダイレクトする→ok
- 削除前に画面の通り、「記事を削除してもよろしいですか？」という確認のアラートを表示させ、「OK」を押した時に記事を論理削除する→ok
- 「キャンセル」を押した場合は削除しない→ok
- 上記の確認アラートはJavaScriptで実装する→ok